### PR TITLE
Generalise ruby interpreter invocation in define_regions_main.rb

### DIFF
--- a/scripts/define_regions_main.rb
+++ b/scripts/define_regions_main.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 require 'optparse'
 require_relative 'define_regions_functions'
 require 'fileutils'


### PR DESCRIPTION
PR generalises the invocation of `ruby` when running the `define_regions_main.rb` script, so that it will use the version on the user's path.
