### PR TITLE
Generalise credible_snps_main.R for sourcing abf.R/creating output dir

### DIFF
--- a/scripts/credible_snps_main.R
+++ b/scripts/credible_snps_main.R
@@ -74,6 +74,15 @@ for(i in seq_along(cred)) {
 
 }
 
+# PJB need to create output dir if not present
+output_dir <- "output/credible_snps/"
+if (!file.exists(output_dir)) {
+
+        print(paste("Creating output dir:",output_dir))
+        dir.create(output_dir)
+
+}
+
 # create summary table
 summary_table <- rbind_all(summ)
 summary_file <- paste("output/credible_snps/summary_table_",opt$cpp,".txt",sep="")

--- a/scripts/credible_snps_main.R
+++ b/scripts/credible_snps_main.R
@@ -5,7 +5,16 @@ library(tidyr)
 library(stringr)
 library(optparse)
 
-source('scripts/abf.R')
+# Locate abf.R regardless of where this script was run from
+# See http://stackoverflow.com/a/6461822
+source_local <- function(fname){
+
+    argv <- commandArgs(trailingOnly = FALSE)
+    base_dir <- dirname(substring(argv[grep("--file=", argv)], 8))
+    source(paste(base_dir, fname, sep="/"))
+
+}
+source_local('abf.R')
 
 option_list = list(
 	make_option(c("-r", "--regions"), type="character", default=NULL,


### PR DESCRIPTION
Pull request attempting to address two issues with the `credible_snps_main.R` script:
- fix limitation whereby the script fails when running from an arbitrary directory (other than the the top-level `CRAFT-GP` directory), by generalising the command to locate the `abf.R` file;
- fix script termination if the `output/credible_snps` directory doesn't already exist, by creating the output directory if it's missing.
