### PR TITLE
Updates to annotation step for running VEP in Galaxy context

### DIFF
--- a/scripts/annotation.py
+++ b/scripts/annotation.py
@@ -82,7 +82,7 @@ def run_vep(input, output):
 
     vep_vcf = output + ".vcf"   
 
-    vep_cmd = "variant_effect_predictor.pl -i %s -o %s --config temp.config" % (input, vep_vcf)
+    vep_cmd = "variant_effect_predictor.pl --no_progress -i %s -o %s --config temp.config" % (input, vep_vcf)
     os.system(vep_cmd)
     os.system("rm temp.config")
 

--- a/scripts/annotation.py
+++ b/scripts/annotation.py
@@ -54,8 +54,6 @@ def write_config_file(eid_list):
                         "core_type          core"   "\n"
                         "dir                source_data/ensembl/cache" "\n"
                         "dir_cache          source_data/ensebl/cache" "\n"
-                        "host               130.88.97.228"  "\n"
-                        "port               3306"   "\n"          
                         "force_overwrite    1"      "\n"
                         "numbers            1"      "\n"
                         "polyphen           p"      "\n"


### PR DESCRIPTION
PR to address issues with VEP when running the `scripts/annotation.py` script in a Galaxy context:
- Prevent VEP attempting to connect to a non-existent MySQL server, resulting in errors of the form:
  
  ```
  2016-07-08 15:56:09 - Read configuration from temp.config
  DBI connect('host=130.88.97.228;port=3306','anonymous',...) failed: Can't connect to MySQL server on '130.88.97.228' (113 "No route to host") at /home/pjb/BCF_Work/projects/CRAFT-GP-galaxy/test.tool_dependencies.craft-gp/vep/84/lib/perl5/Bio/EnsEMBL/Registry.pm line 1761
  ```
  
  Removing the `host` and `port` options from the temporary config file seems to prevent this error occuring.
- Run VEP with the `--no_progress` option to prevent it blocking indefinitely when run in a Galaxy context.
