### PR TITLE
Generate output file paths more robustly

### DIFF
--- a/scripts/credible_snps_main.R
+++ b/scripts/credible_snps_main.R
@@ -89,19 +89,19 @@ for(i in seq_along(cred)) {
 
 # create summary table
 summary_table <- rbind_all(summ)
-summary_file <- paste(opt$out, "summary_table_", opt$cpp,".txt",sep="")
+summary_file <- file.path(opt$out, paste("summary_table_", opt$cpp,".txt",sep=""))
 write_delim(summary_table, delim = " ", summary_file)
 
 # create credible snp table
 credible_snps <- do.call("rbind",cred)
-credible_file <- paste(opt$out, "credible_snps_", opt$cpp,".txt",sep="")
+credible_file <- file.path(opt$out, paste("credible_snps_", opt$cpp,".txt",sep=""))
 write_delim(credible_snps, delim = " ", credible_file)
 
 # create list of credible SNP rs numbers for VEP input
 credible_snp_list <- credible_snps %>%
 	dplyr::select(SNPID)
 
-credible_snp_list_file = paste(opt$out, "credible_snp_list_", opt$cpp,".txt",sep="")
+credible_snp_list_file = file.path(opt$out, paste("credible_snp_list_", opt$cpp,".txt",sep=""))
 write_delim(credible_snp_list, delim = " ", credible_snp_list_file, col_names = FALSE)
 
 # create data for bed file tracks
@@ -116,7 +116,7 @@ cred_snps <- credible_snps %>%
         dplyr::select(chr, start, POS, SNPID)
 
 # create bed file
-bed_file <- paste(opt$out, "credible_snps_", opt$cpp,".bed",sep="")
+bed_file <- file.path(opt$out, paste("credible_snps_", opt$cpp,".bed",sep=""))
 #cat("track name=\"cred\" description=\"Cred interval\" visibility=1", file = bed_file, sep = "\n")
 #write_delim(cred_region, bed_file, delim = " ", col_names = FALSE, append = TRUE)
 cat("track name=\"credSNPs\" description=\"Cred SNPs\" visibility=1", file = bed_file, sep = "\n")

--- a/scripts/define_regions_functions.rb
+++ b/scripts/define_regions_functions.rb
@@ -202,9 +202,9 @@ def write_output(output_data,cmoutput, output)
 		#path = "output/regions/supplementary/regions_"+ cM_m + "cm.txt"
 		#path_bound = "output/regions/supplementary/boundaries_"+ cM_m + "cm.txt"
 		#path_bound_red = "output/regions/region_boundaries_"+ cM_m + "cm.txt"
-    path = output + "/supplementary/regions_"+ cM_m + "cm.txt"
-    path_bound = output + "/supplementary/boundaries_"+ cM_m + "cm.txt"
-    path_bound_red = output + "region_boundaries_"+ cM_m + "cm.txt"
+    path = File.join(output,"supplementary","regions_"+ cM_m + "cm.txt")
+    path_bound = File.join(output,"supplementary","boundaries_"+ cM_m + "cm.txt")
+    path_bound_red = File.join(output,"region_boundaries_"+ cM_m + "cm.txt")
 		dirs = [path,path_bound,path_bound_red]
 		dirs.each do |dir|
 			dirname = File.dirname(dir)
@@ -237,7 +237,7 @@ def write_output(output_data,cmoutput, output)
 		o_file.close()
 
 		if !snps_not_range.empty?
-			path = "output/regions/supplementary/snps_not_in_range.txt"
+			path = File.join(output,"supplementary","snps_not_in_range.txt")
 			#path = "outputs/snps_not_in_range.txt"
 			dirname = File.dirname(path)
 			unless File.directory?(dirname)
@@ -260,7 +260,7 @@ def write_output(output_data,cmoutput, output)
 
 	elsif !cmoutput 
 		puts("BP")
-		path_bound_red = "output/regions/red_boundaries_"+ $bp.to_s + "bp.txt"
+		path_bound_red = File.join(output,"red_boundaries_"+ $bp.to_s + "bp.txt")
 		dirname = File.dirname(path_bound_red)
 		unless File.directory?(dirname)
 			FileUtils.mkdir_p(dirname)

--- a/scripts/define_regions_main.rb
+++ b/scripts/define_regions_main.rb
@@ -9,7 +9,7 @@ $cM = 0.1
 $bp = 0
 
 input = ""
-output = ""
+output = Dir.pwd
 sInputPvals = ""
 
 # Parser for the arguments

--- a/scripts/define_regions_main.rb
+++ b/scripts/define_regions_main.rb
@@ -87,7 +87,7 @@ write_output(output_data,cm_output,output)
 #end
 
 if $bp==0
-  path_bound_red = output + $cM.to_s.gsub(".","") + "cm.txt"
+  path_bound_red = File.join(output,$cM.to_s.gsub(".","") + "cm.txt")
 else
-  path_bound_red = output + $bp.to_s + "bp.txt"
+  path_bound_red = File.join(output,$bp.to_s + "bp.txt")
 end


### PR DESCRIPTION
PR to generate output file paths more robustly:
- Use `File.join(...)` to assemble file paths in ruby scripts (see e.g. http://stackoverflow.com/a/597496/579925)
- Use `file.join(...)` to perform similar operation in R scripts (see e.g. https://stat.ethz.ch/R-manual/R-devel/library/base/html/file.path.html)

This prevents output files being named e.g. `output/credible_snpscredible_snp_list_0.99.txt` rather than `output/credible_snps/credible_snp_list_0.99.txt` if the user neglects to supply a trailing slash on the output directory name.
