### PR TITLE
Generalise visualisation_main.R for sourcing visualisation_functions.R

### DIFF
--- a/scripts/visualisation_main.R
+++ b/scripts/visualisation_main.R
@@ -5,7 +5,16 @@ library(biomaRt)
 library(optparse)
 library(stringr)
 
-source('scripts/visualisation_functions.R')
+# Locate visualisation_functions.R regardless of where this script was run from
+# See http://stackoverflow.com/a/6461822
+source_local <- function(fname){
+
+    argv <- commandArgs(trailingOnly = FALSE)
+    base_dir <- dirname(substring(argv[grep("--file=", argv)], 8))
+    source(paste(base_dir, fname, sep="/"))
+
+}
+source_local('visualisation_functions.R')
 
 # OPTIONS
 


### PR DESCRIPTION
Pull request attempting to address an issue with the `visualisation_main.R` script, whereby the script fails when running from an arbitrary directory (other than the the top-level CRAFT-GP directory), by generalising the command to locate the `visualisation_functions.R` file.

This is essentially the same fix as has already been applied for locating `abf.R` from `credible_snps_main.R` (commit https://github.com/johnbowes/CRAFT-GP/commit/a7e6cc360274d578a9de0fd1156b25cf9a95b56b in PR #4).
